### PR TITLE
Fix memory leak and "unique" bug

### DIFF
--- a/lib/AnyEvent/Gearman/Client/Connection.pm
+++ b/lib/AnyEvent/Gearman/Client/Connection.pm
@@ -13,6 +13,7 @@ sub add_task {
         sub {
             push @{ $self->_need_handle }, $task;
             $self->handler->push_write( $task->pack_req($type) );
+            $on_complete->();
         },
         $on_error,
     );

--- a/lib/AnyEvent/Gearman/Connection.pm
+++ b/lib/AnyEvent/Gearman/Connection.pm
@@ -97,7 +97,7 @@ sub connect {
                 on_read  => sub { $self->process_packet },
                 on_error => sub {
                     my @undone = @{ $self->_need_handle },
-                                 values %{ $self->_job_handles };
+                                 map { @$_ } values %{ $self->_job_handles };
                     $_->event('on_fail') for @undone;
 
                     $self->_need_handle([]);

--- a/t/06_coalesce.t
+++ b/t/06_coalesce.t
@@ -21,7 +21,8 @@ sub run_tests {
         prefix      => 'prefix',
     );
 
-    # test that jobs with the same handle 
+    # test that coalesced jobs from the same client all have their callbacks
+    # fired and have the same value returned
 
     my %success;
     my $cv = AnyEvent->condvar;
@@ -29,8 +30,11 @@ sub run_tests {
     # timeout if a job's callbacks are never called
     my $watchdog = AE::timer(1, 0, sub { $cv->send });
 
-    # subject the same job several times; the 'sleep' worker sleeps for a brief time
-    # to make sure the jobs won't complete before all of them are submitted
+    # submit the same job several times; the 'sleep' worker sleeps for a brief time
+    # to make sure the jobs won't complete until all of them are submitted.
+    # TODO: fix sleep race condition. could be done by only having worker
+    # function return once it receives a SIGUSR1 or something from this client.
+
     my $jobs = 3;
     $cv->begin(sub { $cv->send });
     for my $task (1 .. $jobs) {

--- a/t/06_coalesce.t
+++ b/t/06_coalesce.t
@@ -1,0 +1,74 @@
+use Test::Base;
+use Test::TCP;
+use AnyEvent::Gearman::Client;
+
+eval q{
+        use Gearman::Worker;
+        use Gearman::Server;
+    };
+if ($@) {
+    plan skip_all
+        => "Gearman::Worker and Gearman::Server are required to run this test";
+}
+
+plan tests => 3;
+
+my $port = empty_port;
+
+sub run_tests {
+    my $client = AnyEvent::Gearman::Client->new(
+        job_servers => ['127.0.0.1:' . $port],
+        prefix      => 'prefix',
+    );
+
+    # test that jobs with the same handle 
+
+    my %success;
+    my $cv = AnyEvent->condvar;
+
+    # timeout if a job's callbacks are never called
+    my $watchdog = AE::timer(1, 0, sub { $cv->send });
+
+    # subject the same job several times; the 'sleep' worker sleeps for a brief time
+    # to make sure the jobs won't complete before all of them are submitted
+    my $jobs = 3;
+    $cv->begin(sub { $cv->send });
+    for my $task (1 .. $jobs) {
+        $cv->begin;
+        $client->add_task(
+            'sleep', 'foo',
+            unique => '-',
+            on_complete => sub {
+                $success{$task} = $_[1];
+                $cv->end;
+            },
+            on_fail => sub {
+                $cv->end;
+            },
+        );
+    }
+    $cv->end;
+    $cv->recv;
+    undef $watchdog;
+
+    # although the sleep worker returns an incremental value for each time it
+    # actually runs, we expect the coalesced jobs all got the same result
+    is($success{$_}, 1, "task $_ got coalesced value") for reverse 1 .. $jobs;
+}
+
+my $child = fork;
+if (!defined $child) {
+    die "fork failed: $!";
+}
+elsif ($child == 0) {
+    my $server = Gearman::Server->new( port => $port );
+    $server->start_worker("$^X t/danga_worker.pl -s 127.0.0.1:$port -p prefix");
+    Danga::Socket->EventLoop;
+}
+else {
+    END { kill 9, $child if $child }
+}
+
+sleep 1;
+
+run_tests;

--- a/t/danga_worker.pl
+++ b/t/danga_worker.pl
@@ -29,5 +29,14 @@ $worker->register_function("sum" => sub {
     $res;
 });
 
+my $times_called = 0;
+$worker->register_function("sleep" => sub {
+    my $job = shift;
+    my $arg = $job->arg;
+
+    select undef, undef, undef, 0.5;
+    return ++$times_called;
+});
+
 $worker->work while 1;
 


### PR DESCRIPTION
These commits respectively fix a memory leak (see https://github.com/typester/anyevent-gearman-perl/issues/1) and a bug in "unique"-specifying tasks.
