### PR TITLE
Fix concatenation in TCP on_error handler

### DIFF
--- a/lib/AnyEvent/Gearman/Connection.pm
+++ b/lib/AnyEvent/Gearman/Connection.pm
@@ -96,8 +96,8 @@ sub connect {
                 fh       => $fh,
                 on_read  => sub { $self->process_packet },
                 on_error => sub {
-                    my @undone = @{ $self->_need_handle },
-                                 values %{ $self->_job_handles };
+                    my @undone = (@{ $self->_need_handle },
+                                 values %{ $self->_job_handles });
                     $_->event('on_fail') for @undone;
 
                     $self->_need_handle([]);


### PR DESCRIPTION
Some on_fail handlers were not called because of incorrect concatenation of arrays (no parentheses).

Fixes #7